### PR TITLE
Support PHP version mangers

### DIFF
--- a/src/PHPFmt.ts
+++ b/src/PHPFmt.ts
@@ -106,12 +106,15 @@ class PHPFmt {
         }
       }
 
+      const execOptions = {cwd: ''};
+      if(Window.activeTextEditor) {
+        execOptions.cwd = path.dirname(Window.activeTextEditor.document.fileName)
+      }
+
       try {
+
         const stdout: Buffer = execSync(
-          `${this.config.php_bin} -r "echo PHP_VERSION_ID;"`,
-          {
-             cwd: path.dirname(vscode_1.window.activeTextEditor.document.fileName)
-          }
+          `${this.config.php_bin} -r "echo PHP_VERSION_ID;"`, execOptions
         );
         if (Number(stdout.toString()) < 50600) {
           return reject(new Error('phpfmt: php version < 5.6'));
@@ -138,7 +141,7 @@ class PHPFmt {
 
       // test whether the php file has syntax error
       try {
-        execSync(`${this.config.php_bin} -l ${fileName}`);
+        execSync(`${this.config.php_bin} -l ${fileName}`, execOptions);
       } catch (e) {
         this.widget.addToOutput(e.message);
         Window.setStatusBarMessage(
@@ -151,7 +154,7 @@ class PHPFmt {
       const args: Array<string> = this.getArgs(fileName);
       args.unshift(path.join(context.extensionPath, PHPFmt.pharRelPath));
 
-      const exec: ChildProcess = spawn(this.config.php_bin, args);
+      const exec: ChildProcess = spawn(this.config.php_bin, args, execOptions);
       this.widget.addToOutput(`${this.config.php_bin} ${args.join(' ')}`);
 
       exec.addListener('error', e => {

--- a/src/PHPFmt.ts
+++ b/src/PHPFmt.ts
@@ -108,7 +108,10 @@ class PHPFmt {
 
       try {
         const stdout: Buffer = execSync(
-          `${this.config.php_bin} -r "echo PHP_VERSION_ID;"`
+          `${this.config.php_bin} -r "echo PHP_VERSION_ID;"`,
+          {
+             cwd: path.dirname(vscode_1.window.activeTextEditor.document.fileName)
+          }
         );
         if (Number(stdout.toString()) < 50600) {
           return reject(new Error('phpfmt: php version < 5.6'));


### PR DESCRIPTION
Sorry for the bad PR, I don't know TypeScript.

This PR sets the current working directory of the child process so PHP version managers work correctly.

By default, the child process current working directory is `process.cwd()`, which might not always be in the project tree. For PHP version managers, `php` needs to be executed inside the project tree so the `.phpversion` (or whatever similar file) is detected correctly. The solution is to set the child process cwd to `path.dirname(Window.activeTextEditor.document.fileName)`.

For example, `.phpversion` inside my project is set to `7.1.3`. But outside my project tree, PHP version is `5.3`. Here is my `mampenv` package that allows a `.phpversion` file to be specified in the root of the project, much like `rbenv` etc. https://github.com/benallfree/mampenv

This will also work for multiple project roots that have different `.phpversion` files.

Hope it's clear :)