### PR TITLE
[Discussion] [Live Share] Restricting formatting to local files

### DIFF
--- a/src/PHPFmtProvider.ts
+++ b/src/PHPFmtProvider.ts
@@ -7,9 +7,15 @@ import {
   Range,
   TextEdit,
   Disposable,
+  DocumentSelector,
   ExtensionContext
 } from 'vscode';
 import PHPFmt from './PHPFmt';
+
+const documentSelector: DocumentSelector = [
+  { language: 'php', scheme: 'file' },
+  { language: 'php', scheme: 'untitled' }
+];
 
 export default class PHPFmtProvider {
   private phpfmt: PHPFmt;
@@ -33,7 +39,7 @@ export default class PHPFmtProvider {
   }
 
   documentFormattingEditProvider(context: ExtensionContext): Disposable {
-    return Languages.registerDocumentFormattingEditProvider('php', {
+    return Languages.registerDocumentFormattingEditProvider(documentSelector, {
       provideDocumentFormattingEdits: document => {
         return new Promise<any>((resolve, reject) => {
           const originalText: string = document.getText();
@@ -64,7 +70,7 @@ export default class PHPFmtProvider {
   }
 
   documentRangeFormattingEditProvider(context: ExtensionContext): Disposable {
-    return Languages.registerDocumentRangeFormattingEditProvider('php', {
+    return Languages.registerDocumentRangeFormattingEditProvider(documentSelector, {
       provideDocumentRangeFormattingEdits: (document, range) => {
         return new Promise<any>((resolve, reject) => {
           let originalText: string = document.getText(range);


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for PHP, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the `phpfmt` extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their formatting will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*