### PR TITLE
Run release workflow on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  schedule:
-    - cron: "*/30 * * * *"
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
Run release workflow when there's a new release instead of on a fixed schedule.